### PR TITLE
fix: draw_point computes index incorrectly

### DIFF
--- a/rendering/rendering.c
+++ b/rendering/rendering.c
@@ -8,6 +8,7 @@
 #include <drm_mode.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <libdrm/drm_fourcc.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -335,6 +336,12 @@ static void init_buf(struct rendering_ctx *ctx, size_t idx)
 	buf_id_t buf_id;
 	target->stride = fb_create.pitch;
 	target->size = fb_create.size;
+
+	if (fb_create.pitch < fb_create.bpp / 8)
+		// This should never happen, save for bugs in the driver.
+		FATAL_ERR("DRM_IOCTL_MODE_CREATE_DUMB gave a stride of %" PRIu32
+			  " bytes, but this cannot fit %" PRIu32 "-bit pixels",
+		    fb_create.pitch, fb_create.bpp);
 
 	uint32_t handles[4] = { fb_create.handle };
 	uint32_t strides[4] = { fb_create.pitch };

--- a/rendering/rendering.c
+++ b/rendering/rendering.c
@@ -434,7 +434,9 @@ static void draw_point(
 {
 	// Color space is little endian, thus the BGRA format used below:
 	uint8_t mapped[4] = { color.b, color.g, color.r, 0xFF };
+	assert(c->stride == sizeof(mapped));
 
-	size_t off = (c->stride * y) + (x * sizeof(mapped));
-	memcpy(&c->buffer[off], mapped, sizeof(mapped));
+	size_t pixel_idx = (size_t)y * (size_t)c->width + (size_t)x;
+	size_t byte_idx = pixel_idx * sizeof(mapped);
+	memcpy(&c->buffer[byte_idx], mapped, sizeof(mapped));
 }

--- a/rendering/rendering.c
+++ b/rendering/rendering.c
@@ -435,9 +435,8 @@ static void draw_point(
 {
 	// Color space is little endian, thus the BGRA format used below:
 	uint8_t mapped[4] = { color.b, color.g, color.r, 0xFF };
-	assert(c->stride == sizeof(mapped));
 
 	size_t pixel_idx = (size_t)y * (size_t)c->width + (size_t)x;
-	size_t byte_idx = pixel_idx * sizeof(mapped);
+	size_t byte_idx = pixel_idx * c->stride;
 	memcpy(&c->buffer[byte_idx], mapped, sizeof(mapped));
 }

--- a/rendering/rendering.c
+++ b/rendering/rendering.c
@@ -2,6 +2,7 @@
 
 #include "abort.h"
 
+#include <assert.h>
 #include <dirent.h>
 #include <drm.h>
 #include <drm_mode.h>


### PR DESCRIPTION
While inspecting canvas data, I noticed that the image wasn't fully filled in after a call to `rendering_fill`. I think the issue lies in `draw_point`'s indexing.

Note: this assumes row-major order as I have not yet checked the dumb buffer docs (though I'm not sure why it *wouldn't* be).

EDIT: The canvas data looks okay in GIMP after applying this fix.