### PR TITLE
WIP: tools for debugging canvas rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 *.swp
 /.cache
+*.data

--- a/debug.c
+++ b/debug.c
@@ -1,0 +1,43 @@
+#include "abort.h"
+#include "rendering/rendering.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+const struct color BG = { .r = 0x3A, .g = 0x22, .b = 0xBD };
+const struct color FG = { .r = 0xFF, .g = 0xFF, .b = 0xFF };
+
+int main(void)
+{
+	// Initialize in-memory canvas.
+	struct canvas *canvas = canvas_init_bgra(32, 32);
+	if (canvas == NULL)
+		FATAL_ERR("out of memory");
+	rendering_fill(canvas, BG);
+
+	// Draw a glider.
+	const uint16_t glider[5][2] = {
+		{ 1, 0 },
+		{ 0, 1 },
+		{ 0, 2 },
+		{ 1, 2 },
+		{ 2, 2 },
+	};
+	const int16_t x0 = 22;
+	const int16_t y0 = 16;
+	for (size_t i = 0; i < sizeof(glider) / sizeof(glider[0]); i++) {
+		uint16_t x = x0 + glider[i][0];
+		uint16_t y = y0 + glider[i][1];
+		rendering_draw_rect(canvas,
+		    &(struct rect) { .w = 1, .h = 1, .x = x, .y = y }, FG);
+	}
+
+	// Save canvas as raw RGBA pixel data.
+	const char *pathname = "canvas-rgba.data";
+	rendering_dump_bgra_to_rgba(canvas, pathname);
+	fprintf(stderr, "Wrote RGBA pixel data to file: %s\n", pathname);
+
+	return 0;
+}

--- a/meson.build
+++ b/meson.build
@@ -9,10 +9,17 @@ add_project_arguments([
   '-pedantic', '-D_POSIX_C_SOURCE=200809L'
 ], language : 'c')
 
-exe = executable('ttds',
+main_exe = executable('ttds',
   'main.c', 'threads/ui.c', 'rendering/rendering.h', 'rendering/rendering.c',
   'threads/input.c', 'threads/termination.c', 'threads/commands.c',
   install : true,
   dependencies : [ libdrm, libsystemd ])
 
-test('basic', exe)
+debug_exe = executable('debug',
+  'debug.c', 'threads/ui.c', 'rendering/rendering.h', 'rendering/rendering.c',
+  'threads/input.c', 'threads/termination.c', 'threads/commands.c',
+  install : true,
+  dependencies : [ libdrm, libsystemd ])
+
+test('basic', main_exe)
+test('debug', debug_exe)

--- a/rendering/rendering.c
+++ b/rendering/rendering.c
@@ -155,39 +155,42 @@ void rendering_draw_circle(
 	uint16_t y = 0;
 	int32_t t1 = circle->r / 16;
 
-	// i copied this off wikipedia lol
 	while (x >= y) {
 		uint16_t eff_y = circle->y + y;
-		uint16_t eff_x = circle->x + x;
-		draw_point(c, eff_x, eff_y, color);
+		for (uint16_t eff_x = circle->x + x; eff_x >= circle->x;
+		    eff_x--)
+			draw_point(c, eff_x, eff_y, color);
 
 		eff_y = circle->y - y;
-		eff_x = circle->x + x;
-		draw_point(c, eff_x, eff_y, color);
+		for (uint16_t eff_x = circle->x + x; eff_x >= circle->x;
+		    eff_x--)
+			draw_point(c, eff_x, eff_y, color);
 
 		eff_y = circle->y - y;
-		eff_x = circle->x - x;
-		draw_point(c, eff_x, eff_y, color);
+		for (uint16_t eff_x = circle->x - x; eff_x < circle->x; eff_x++)
+			draw_point(c, eff_x, eff_y, color);
 
 		eff_y = circle->y + y;
-		eff_x = circle->x - x;
-		draw_point(c, eff_x, eff_y, color);
+		for (uint16_t eff_x = circle->x - x; eff_x < circle->x; eff_x++)
+			draw_point(c, eff_x, eff_y, color);
 
 		eff_y = circle->y + x;
-		eff_x = circle->x + y;
-		draw_point(c, eff_x, eff_y, color);
+		for (uint16_t eff_x = circle->x + y; eff_x >= circle->x;
+		    eff_x--)
+			draw_point(c, eff_x, eff_y, color);
 
 		eff_y = circle->y - x;
-		eff_x = circle->x + y;
-		draw_point(c, eff_x, eff_y, color);
+		for (uint16_t eff_x = circle->x + y; eff_x >= circle->x;
+		    eff_x--)
+			draw_point(c, eff_x, eff_y, color);
 
 		eff_y = circle->y - x;
-		eff_x = circle->x - y;
-		draw_point(c, eff_x, eff_y, color);
+		for (uint16_t eff_x = circle->x - y; eff_x < circle->x; eff_x++)
+			draw_point(c, eff_x, eff_y, color);
 
 		eff_y = circle->y + x;
-		eff_x = circle->x - y;
-		draw_point(c, eff_x, eff_y, color);
+		for (uint16_t eff_x = circle->x - y; eff_x < circle->x; eff_x++)
+			draw_point(c, eff_x, eff_y, color);
 
 		y++;
 		t1 = t1 + y;

--- a/rendering/rendering.c
+++ b/rendering/rendering.c
@@ -434,7 +434,9 @@ static void draw_point(
 {
 	// Color space is little endian, thus the BGRA format used below:
 	uint8_t mapped[4] = { color.b, color.g, color.r, 0xFF };
+	assert(c->stride == sizeof(mapped));
 
-	size_t off = (c->stride * y) + (x * sizeof(mapped));
-	memcpy(&c->buffer[off], mapped, sizeof(mapped));
+	size_t pixel_idx = (size_t)y * (size_t)c->width + (size_t)x;
+	size_t byte_idx = pixel_idx * sizeof(mapped);
+	memcpy(&c->buffer[byte_idx], mapped, sizeof(mapped));
 }

--- a/rendering/rendering.c
+++ b/rendering/rendering.c
@@ -8,7 +8,6 @@
 #include <drm_mode.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <inttypes.h>
 #include <libdrm/drm_fourcc.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -393,12 +392,6 @@ static void init_buf(struct rendering_ctx *ctx, size_t idx)
 	target->stride = fb_create.pitch;
 	target->size = fb_create.size;
 
-	if (fb_create.pitch < fb_create.bpp / 8)
-		// This should never happen, save for bugs in the driver.
-		FATAL_ERR("DRM_IOCTL_MODE_CREATE_DUMB gave a stride of %" PRIu32
-			  " bytes, but this cannot fit %" PRIu32 "-bit pixels",
-		    fb_create.pitch, fb_create.bpp);
-
 	uint32_t handles[4] = { fb_create.handle };
 	uint32_t strides[4] = { fb_create.pitch };
 	uint32_t offsets[4] = { 0 };
@@ -505,7 +498,6 @@ static void draw_point(
 	// Color space is little endian, thus the BGRA format used below:
 	uint8_t mapped[4] = { color.b, color.g, color.r, 0xFF };
 
-	size_t pixel_idx = (size_t)y * (size_t)c->width + (size_t)x;
-	size_t byte_idx = pixel_idx * c->stride;
-	memcpy(&c->buffer[byte_idx], mapped, sizeof(mapped));
+	size_t off = (c->stride * y) + (x * sizeof(mapped));
+	memcpy(&c->buffer[off], mapped, sizeof(mapped));
 }

--- a/rendering/rendering.c
+++ b/rendering/rendering.c
@@ -2,6 +2,7 @@
 
 #include "abort.h"
 
+#include <assert.h>
 #include <dirent.h>
 #include <drm.h>
 #include <drm_mode.h>

--- a/rendering/rendering.h
+++ b/rendering/rendering.h
@@ -17,7 +17,12 @@ struct circle {
 	uint16_t r;
 };
 
-struct canvas;
+struct canvas {
+	uint16_t width, height;
+	uint32_t stride;
+	uint8_t *buffer;
+};
+
 struct rendering_ctx;
 
 struct rendering_ctx *rendering_init(void);
@@ -26,7 +31,10 @@ void rendering_cleanup(struct rendering_ctx *);
 void rendering_ctx_log(const struct rendering_ctx *);
 
 struct canvas *canvas_init(struct rendering_ctx *);
+struct canvas *canvas_init_bgra(uint16_t, uint16_t);
 void canvas_deinit(struct canvas *);
+
+uint64_t canvas_buffer_size(const struct canvas *);
 
 void rendering_fill(struct canvas *, struct color);
 void rendering_draw_rect(struct canvas *, const struct rect *, struct color);
@@ -35,3 +43,5 @@ void rendering_draw_circle(
     struct canvas *, const struct circle *, struct color);
 
 void rendering_show(struct rendering_ctx *, struct canvas *);
+
+void rendering_dump_bgra_to_rgba(const struct canvas *, const char *);


### PR DESCRIPTION
## TODOs
- [ ] I haven't used Meson before so I've temporarily copy pasted the declaration for executable `main.c`.
- [X] ~~It would be nice to be able to compile the in-memory canvas stuff without `libdrm` or `libsystemd`, but the canvas rendering functions would need to be moved out of the DRM code.~~ See https://github.com/atalii/ttds/pull/11
- [X] I misunderstood the semantics of stride/pitch (see https://github.com/atalii/ttds/pull/1)
- [ ] Generate test cases as part of main executable for convenience + code sharing
- (everything else)