### PR TITLE
fix: bounds check `draw_point`

### DIFF
--- a/rendering/rendering.c
+++ b/rendering/rendering.c
@@ -432,6 +432,12 @@ static bool is_primary_plane(struct rendering_ctx *ctx, plane_id_t plane_id)
 static void draw_point(
     struct canvas *c, uint16_t x, uint16_t y, struct color color)
 {
+	// Drawing a point out of bounds is a no-op. This is
+	// especially important given that we're receiving
+	// arbitrary commands.
+	if (c->width <= x || c->height <= y)
+		return;
+
 	// Color space is little endian, thus the BGRA format used below:
 	uint8_t mapped[4] = { color.b, color.g, color.r, 0xFF };
 


### PR DESCRIPTION
Since `draw_point` writes to memory as directed by arbitrary commands, it should probably check bounds.

As an addendum to this PR, I'm not sure if it's worth checking for overflow when drawing rectangles and stuff, as it's defined to wrap around for unsigned integers and the worst that could happen is that it looks silly.