### PR TITLE
fix: incorrect array size passed to poll(2)

### DIFF
--- a/display/threads/ui.c
+++ b/display/threads/ui.c
@@ -181,7 +181,7 @@ static void *rotate_panes(void *arg)
 		clock_gettime(CLOCK_MONOTONIC_RAW, &a); // TODO: error checking
 
 		// Do a cancellable 1-second sleep.
-		poll(fds, 1, sleep_time);
+		poll(fds, sizeof(fds) / sizeof(*fds), sleep_time);
 		if (fds[0].revents &= POLLIN) {
 			// cancellation fd
 			break;


### PR DESCRIPTION
I think this is the issue valgrind was complaining about (I was testing on my branch `test-backend`):

```
==29147== Memcheck, a memory error detector
==29147== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==29147== Using Valgrind-3.24.0 and LibVEX; rerun with -h for copyright info
==29147== Command: ./build/ttds --backend mem
==29147== 
Size:	128x128
ui: flipping pane: root
==29147== Thread 5:
==29147== Conditional jump or move depends on uninitialised value(s)
==29147==    at 0x10B6E3: rotate_panes (ui.c:188)
==29147==    by 0x40669D1: start (pthread_create.c:207)
==29147==    by 0x4068313: ??? (clone.s:22)
==29147== 
...
```