### PR TITLE
fix(display): make loop termination in line drawing clearer

### DIFF
--- a/display/rendering/canvas.c
+++ b/display/rendering/canvas.c
@@ -185,7 +185,7 @@ DEFN_RENDER(line, {
 	int32_t d1_x = -steps * (step_x + lstep_x);
 	int32_t d1_y = -steps * (step_y + lstep_y);
 
-	for (uint16_t i = 0; i <= steps; i++) {
+	for (int32_t i = 0; i <= steps; i++) {
 		draw_point(c, x, y, color);
 
 		const int32_t px = abs(d0_x) - abs(d1_x);


### PR DESCRIPTION
Both `i` and `steps` are `uint16_t`s compared via `<=`. The only reason why this can't loop indefinitely for UINT16_MAX steps is that it happens to be a "small" integer, thus coerces to an `int`, which happens to be bigger.